### PR TITLE
Add header navigation links

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="container mx-auto p-4">
+    <header class="mb-4">
+      <h1 class="text-2xl font-bold">Welkom</h1>
+      <nav class="mt-2 flex gap-4">
+        <NuxtLink to="/oppotten" class="text-blue-500">Oppotten</NuxtLink>
+        <NuxtLink to="/potworm" class="text-blue-500">Potworm</NuxtLink>
+        <NuxtLink to="/trips" class="text-blue-500">Trips</NuxtLink>
+        <NuxtLink to="/ziekzoeken" class="text-blue-500">Ziekzoeken</NuxtLink>
+      </nav>
+    </header>
     <slot />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add navigation links for all pages in the default layout header

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413e31f9c883279782625b7d2889bf