### PR TITLE
Fix bcryptjs import in auth handler

### DIFF
--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -1,8 +1,11 @@
-import CredentialsProvider from 'next-auth/providers/credentials'
+import CredentialsProviderImport from 'next-auth/providers/credentials'
 import { NuxtAuthHandler } from '#auth'
 import { prisma } from '../../prisma'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
+
+const CredentialsProvider =
+  (CredentialsProviderImport as any).default || CredentialsProviderImport
 
 export default NuxtAuthHandler({
   secret: process.env.AUTH_SECRET,

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -2,7 +2,7 @@ import CredentialsProvider from 'next-auth/providers/credentials'
 import { NuxtAuthHandler } from '#auth'
 import { prisma } from '../../prisma'
 import { PrismaAdapter } from '@auth/prisma-adapter'
-import { compare } from 'bcryptjs'
+import bcrypt from 'bcryptjs'
 
 export default NuxtAuthHandler({
   secret: process.env.AUTH_SECRET,
@@ -20,7 +20,7 @@ export default NuxtAuthHandler({
         }
         const user = await prisma.user.findUnique({ where: { email: credentials.email } })
         if (!user) return null
-        const valid = await compare(credentials.password, user.password)
+        const valid = await bcrypt.compare(credentials.password, user.password)
         if (!valid) return null
         return { id: user.id, email: user.email }
       }


### PR DESCRIPTION
## Summary
- import bcryptjs as default object in server auth handler
- use `bcrypt.compare` to validate passwords

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417d1900d483279fa68ebf26883e63